### PR TITLE
Fix malformed json

### DIFF
--- a/code/ProcessRCS.m
+++ b/code/ProcessRCS.m
@@ -322,188 +322,204 @@ if processFlag == 1 || processFlag == 2
     %%
     % First, need to create unifiedDerivedTimes - which has DerivedTimes
     % filling in the gaps (even when there is no TD data)
-    unifiedDerivedTimes = timeDomainData.DerivedTime(1):1000/srates_TD(1):timeDomainData.DerivedTime(end);
-    unifiedDerivedTimes = unifiedDerivedTimes';
-    
-    % Time format for human-readable time
-    timeFormat = sprintf('%+03.0f:00',metaData.UTCoffset);
-    
-    % Harmonize Accel with unifiedDerivedTimes
-    if ~isempty(AccelData)
-        disp('Harmonizing time of Accelerometer data with unifiedDerivedTimes')
-        derivedTime_Accel = AccelData.DerivedTime;
-        [newDerivedTime,newDerivedTimes_Accel] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Accel, srates_TD(1));
-        
-        % Update unifiedDerivedTimes with newDerivedTime, as additional times
-        % may have been added at the beginning and/or end
-        unifiedDerivedTimes = newDerivedTime;
-        
-        % Add newDerivedTime to AccelData
-        AccelData.newDerivedTime = newDerivedTimes_Accel;
-        AccelData = movevars(AccelData, 'newDerivedTime','Before',1);
-        
-        % Add human-readable version of newDerivedTime to AccelData
-        localTime = datetime(AccelData.newDerivedTime/1000,...
+    if ~isempty(timeDomainData)
+        unifiedDerivedTimes = timeDomainData.DerivedTime(1):1000/srates_TD(1):timeDomainData.DerivedTime(end);
+        unifiedDerivedTimes = unifiedDerivedTimes';
+
+        % Time format for human-readable time
+        timeFormat = sprintf('%+03.0f:00',metaData.UTCoffset);
+
+        % Harmonize Accel with unifiedDerivedTimes
+        if ~isempty(AccelData)
+            disp('Harmonizing time of Accelerometer data with unifiedDerivedTimes')
+            derivedTime_Accel = AccelData.DerivedTime;
+            [newDerivedTime,newDerivedTimes_Accel] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Accel, srates_TD(1));
+
+            % Update unifiedDerivedTimes with newDerivedTime, as additional times
+            % may have been added at the beginning and/or end
+            unifiedDerivedTimes = newDerivedTime;
+
+            % Add newDerivedTime to AccelData
+            AccelData.newDerivedTime = newDerivedTimes_Accel;
+            AccelData = movevars(AccelData, 'newDerivedTime','Before',1);
+
+            % Add human-readable version of newDerivedTime to AccelData
+            localTime = datetime(AccelData.newDerivedTime/1000,...
+                'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
+            AccelData = addvars(AccelData,localTime,'Before',1);
+
+            % Create sparse matrix with only timing variables
+            subsetAccelData = AccelData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
+            AccelData_onlyTimeVariables = table2array(subsetAccelData);
+            AccelData_onlyTimeVariables(isnan(AccelData_onlyTimeVariables)) = 0;
+            AccelData_onlyTimeVariables = sparse(AccelData_onlyTimeVariables);
+            Accel_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
+
+            % Remove un-needed variables from AccelData
+            AccelData = removevars(AccelData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
+                'PacketRxUnixTime','dataTypeSequence','packetsizes'});
+        else
+            AccelData_onlyTimeVariables = [];
+            Accel_timeVariableNames = [];
+        end
+
+        % Harmonize Power with unifiedDerivedTimes
+        if ~isempty(PowerData)
+            disp('Harmonizing time of Power data with unifiedDerivedTimes')
+            derivedTime_Power = PowerData.DerivedTime;
+            [newDerivedTime,newDerivedTimes_Power] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Power, srates_TD(1));
+
+            % Update unifiedDerivedTimes with newDerivedTime, as additional times
+            % may have been added at the beginning and/or end
+            unifiedDerivedTimes = newDerivedTime;
+
+            % Add newDerivedTime to PowerData
+            PowerData.newDerivedTime = newDerivedTimes_Power;
+            PowerData = movevars(PowerData, 'newDerivedTime','Before',1);
+
+            % Add human-readable version of newDerivedTime to PowerData
+            localTime = datetime(PowerData.newDerivedTime/1000,...
+                'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
+            PowerData = addvars(PowerData,localTime,'Before',1);
+
+            % Create sparse matrix with only timing variables
+            subsetPowerData = PowerData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
+            PowerData_onlyTimeVariables = table2array(subsetPowerData);
+            PowerData_onlyTimeVariables(isnan(PowerData_onlyTimeVariables)) = 0;
+            PowerData_onlyTimeVariables = sparse(PowerData_onlyTimeVariables);
+            Power_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
+
+            % Remove un-needed variables from PowerData
+            PowerData = removevars(PowerData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
+                'PacketRxUnixTime','dataTypeSequence','packetsizes'});
+        else
+            PowerData_onlyTimeVariables = [];
+            Power_timeVariableNames = [];
+        end
+
+        % Harmonize FFT with unifiedDerivedTimes
+        if ~isempty(FFTData)
+            disp('Harmonizing time of FFT data with unifiedDerivedTimes')
+            derivedTime_FFT = FFTData.DerivedTime;
+            [newDerivedTime,newDerivedTimes_FFT] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_FFT, srates_TD(1));
+
+            % Update unifiedDerivedTimes with newDerivedTime, as additional times
+            % may have been added at the beginning and/or end
+            unifiedDerivedTimes = newDerivedTime;
+
+            FFTData.newDerivedTime = newDerivedTimes_FFT;
+            FFTData = movevars(FFTData, 'newDerivedTime','Before',1);
+
+            % Add human-readable version of newDerivedTime to FFTData
+            localTime = datetime(FFTData.newDerivedTime/1000,...
+                'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
+            FFTData = addvars(FFTData,localTime,'Before',1);
+
+            % Create sparse matrix with only timing variables
+            subsetFFTData = FFTData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
+            FFTData_onlyTimeVariables = table2array(subsetFFTData);
+            FFTData_onlyTimeVariables(isnan(FFTData_onlyTimeVariables)) = 0;
+            FFTData_onlyTimeVariables = sparse(FFTData_onlyTimeVariables);
+            FFT_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
+
+            % Remove un-needed variables from FFTData
+            FFTData = removevars(FFTData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
+                'PacketRxUnixTime','dataTypeSequence','packetsizes'});
+        else
+            FFTData_onlyTimeVariables = [];
+            FFT_timeVariableNames = [];
+        end
+
+        % Harmonize Adaptive with unifiedDerivedTimes
+        if ~isempty(AdaptiveData)
+            disp('Harmonizing time of Adaptive data with unifiedDerivedTimes')
+            derivedTime_Adaptive = AdaptiveData.DerivedTime;
+            [newDerivedTime,newDerivedTimes_Adaptive] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Adaptive, srates_TD(1));
+
+            % Update unifiedDerivedTimes with newDerivedTime, as additional times
+            % may have been added at the beginning and/or end
+            unifiedDerivedTimes = newDerivedTime;
+
+            AdaptiveData.newDerivedTime = newDerivedTimes_Adaptive;
+            AdaptiveData = movevars(AdaptiveData, 'newDerivedTime','Before',1);
+
+            % Add human-readable version of newDerivedTime to AdaptiveData
+            localTime = datetime(AdaptiveData.newDerivedTime/1000,...
+                'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
+            AdaptiveData = addvars(AdaptiveData,localTime,'Before',1);
+
+            % Create sparse matrix with only timing variables
+            subsetAdaptiveData = AdaptiveData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
+            AdaptiveData_onlyTimeVariables = table2array(subsetAdaptiveData);
+            AdaptiveData_onlyTimeVariables(isnan(AdaptiveData_onlyTimeVariables)) = 0;
+            AdaptiveData_onlyTimeVariables = sparse(AdaptiveData_onlyTimeVariables);
+            Adaptive_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
+
+            % Remove un-needed variables from AdaptiveData
+            AdaptiveData = removevars(AdaptiveData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
+                'PacketRxUnixTime','dataTypeSequence','packetsizes'});
+        else
+            AdaptiveData_onlyTimeVariables = [];
+            Adaptive_timeVariableNames = [];
+        end
+
+        %%
+        % Separate timeDomainData for saving
+
+        % Add human-readable version of DerivedTime to timeDomainData
+        localTime = datetime(timeDomainData.DerivedTime/1000,...
             'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
-        AccelData = addvars(AccelData,localTime,'Before',1);
-        
+        timeDomainData = addvars(timeDomainData,localTime,'Before',1);
+
         % Create sparse matrix with only timing variables
-        subsetAccelData = AccelData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
-        AccelData_onlyTimeVariables = table2array(subsetAccelData);
-        AccelData_onlyTimeVariables(isnan(AccelData_onlyTimeVariables)) = 0;
-        AccelData_onlyTimeVariables = sparse(AccelData_onlyTimeVariables);
-        Accel_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
-        
-        % Remove un-needed variables from AccelData
-        AccelData = removevars(AccelData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
+        subsetTimeDomainData = timeDomainData(:,{'DerivedTime','timestamp','systemTick','PacketGenTime'});
+        timeDomainData_onlyTimeVariables = table2array(subsetTimeDomainData);
+        timeDomainData_onlyTimeVariables(isnan(timeDomainData_onlyTimeVariables)) = 0;
+        timeDomainData_onlyTimeVariables = sparse(timeDomainData_onlyTimeVariables);
+        timeDomain_timeVariableNames = {'DerivedTime','timestamp','systemTick','PacketGenTime'};
+
+        % Remove un-needed variables from TimeDomainData
+        timeDomainData = removevars(timeDomainData, {'timestamp','systemTick','PacketGenTime',...
             'PacketRxUnixTime','dataTypeSequence','packetsizes'});
+
+        %%
+        % Load txt file with code version
+
+        currentFunctionPath = mfilename('fullpath');
+        [filepath, name, ext] = fileparts(currentFunctionPath);
+        toLoad = [filepath filesep 'VersionInfo.txt'];
+
+        versionInfo = importdata(toLoad);
+
+        %%
+        % Save output file if indicated
+        if processFlag == 1
+            disp('Saving output')
+
+            save(outputFileName,'unifiedDerivedTimes',...
+                'timeDomainData','timeDomainData_onlyTimeVariables','timeDomain_timeVariableNames',...
+                'AccelData','AccelData_onlyTimeVariables','Accel_timeVariableNames',...
+                'PowerData','PowerData_onlyTimeVariables','Power_timeVariableNames',...
+                'FFTData','FFTData_onlyTimeVariables','FFT_timeVariableNames',...
+                'AdaptiveData','AdaptiveData_onlyTimeVariables','Adaptive_timeVariableNames',...
+                'timeDomainSettings','powerSettings','fftSettings','eventLogTable','metaData',...
+                'stimSettingsOut','stimMetaData','stimLogSettings','DetectorSettings','AdaptiveStimSettings',...
+                'AdaptiveEmbeddedRuns_StimSettings','versionInfo','-v7.3');
+        end
     else
-        AccelData_onlyTimeVariables = [];
-        Accel_timeVariableNames = [];
-    end
-    
-    % Harmonize Power with unifiedDerivedTimes
-    if ~isempty(PowerData)
-        disp('Harmonizing time of Power data with unifiedDerivedTimes')
-        derivedTime_Power = PowerData.DerivedTime;
-        [newDerivedTime,newDerivedTimes_Power] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Power, srates_TD(1));
-        
-        % Update unifiedDerivedTimes with newDerivedTime, as additional times
-        % may have been added at the beginning and/or end
-        unifiedDerivedTimes = newDerivedTime;
-        
-        % Add newDerivedTime to PowerData
-        PowerData.newDerivedTime = newDerivedTimes_Power;
-        PowerData = movevars(PowerData, 'newDerivedTime','Before',1);
-        
-        % Add human-readable version of newDerivedTime to PowerData
-        localTime = datetime(PowerData.newDerivedTime/1000,...
-            'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
-        PowerData = addvars(PowerData,localTime,'Before',1);
-        
-        % Create sparse matrix with only timing variables
-        subsetPowerData = PowerData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
-        PowerData_onlyTimeVariables = table2array(subsetPowerData);
-        PowerData_onlyTimeVariables(isnan(PowerData_onlyTimeVariables)) = 0;
-        PowerData_onlyTimeVariables = sparse(PowerData_onlyTimeVariables);
-        Power_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
-        
-        % Remove un-needed variables from PowerData
-        PowerData = removevars(PowerData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
-            'PacketRxUnixTime','dataTypeSequence','packetsizes'});
-    else
-        PowerData_onlyTimeVariables = [];
-        Power_timeVariableNames = [];
-    end
-    
-    % Harmonize FFT with unifiedDerivedTimes
-    if ~isempty(FFTData)
-        disp('Harmonizing time of FFT data with unifiedDerivedTimes')
-        derivedTime_FFT = FFTData.DerivedTime;
-        [newDerivedTime,newDerivedTimes_FFT] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_FFT, srates_TD(1));
-        
-        % Update unifiedDerivedTimes with newDerivedTime, as additional times
-        % may have been added at the beginning and/or end
-        unifiedDerivedTimes = newDerivedTime;
-        
-        FFTData.newDerivedTime = newDerivedTimes_FFT;
-        FFTData = movevars(FFTData, 'newDerivedTime','Before',1);
-        
-        % Add human-readable version of newDerivedTime to FFTData
-        localTime = datetime(FFTData.newDerivedTime/1000,...
-            'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
-        FFTData = addvars(FFTData,localTime,'Before',1);
-        
-        % Create sparse matrix with only timing variables
-        subsetFFTData = FFTData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
-        FFTData_onlyTimeVariables = table2array(subsetFFTData);
-        FFTData_onlyTimeVariables(isnan(FFTData_onlyTimeVariables)) = 0;
-        FFTData_onlyTimeVariables = sparse(FFTData_onlyTimeVariables);
-        FFT_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
-        
-        % Remove un-needed variables from FFTData
-        FFTData = removevars(FFTData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
-            'PacketRxUnixTime','dataTypeSequence','packetsizes'});
-    else
-        FFTData_onlyTimeVariables = [];
-        FFT_timeVariableNames = [];
-    end
-    
-    % Harmonize Adaptive with unifiedDerivedTimes
-    if ~isempty(AdaptiveData)
-        disp('Harmonizing time of Adaptive data with unifiedDerivedTimes')
-        derivedTime_Adaptive = AdaptiveData.DerivedTime;
-        [newDerivedTime,newDerivedTimes_Adaptive] = harmonizeTimeAcrossDataStreams(unifiedDerivedTimes, derivedTime_Adaptive, srates_TD(1));
-        
-        % Update unifiedDerivedTimes with newDerivedTime, as additional times
-        % may have been added at the beginning and/or end
-        unifiedDerivedTimes = newDerivedTime;
-        
-        AdaptiveData.newDerivedTime = newDerivedTimes_Adaptive;
-        AdaptiveData = movevars(AdaptiveData, 'newDerivedTime','Before',1);
-        
-        % Add human-readable version of newDerivedTime to AdaptiveData
-        localTime = datetime(AdaptiveData.newDerivedTime/1000,...
-            'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
-        AdaptiveData = addvars(AdaptiveData,localTime,'Before',1);
-        
-        % Create sparse matrix with only timing variables
-        subsetAdaptiveData = AdaptiveData(:,{'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'});
-        AdaptiveData_onlyTimeVariables = table2array(subsetAdaptiveData);
-        AdaptiveData_onlyTimeVariables(isnan(AdaptiveData_onlyTimeVariables)) = 0;
-        AdaptiveData_onlyTimeVariables = sparse(AdaptiveData_onlyTimeVariables);
-        Adaptive_timeVariableNames = {'newDerivedTime','DerivedTime','timestamp','systemTick','PacketGenTime'};
-        
-        % Remove un-needed variables from AdaptiveData
-        AdaptiveData = removevars(AdaptiveData, {'DerivedTime','timestamp','systemTick','PacketGenTime',...
-            'PacketRxUnixTime','dataTypeSequence','packetsizes'});
-    else
-        AdaptiveData_onlyTimeVariables = [];
-        Adaptive_timeVariableNames = [];
-    end
-    
-    %%
-    % Separate timeDomainData for saving
-    
-    % Add human-readable version of DerivedTime to timeDomainData
-    localTime = datetime(timeDomainData.DerivedTime/1000,...
-        'ConvertFrom','posixTime','TimeZone',timeFormat,'Format','dd-MMM-yyyy HH:mm:ss.SSS');
-    timeDomainData = addvars(timeDomainData,localTime,'Before',1);
-    
-    % Create sparse matrix with only timing variables
-    subsetTimeDomainData = timeDomainData(:,{'DerivedTime','timestamp','systemTick','PacketGenTime'});
-    timeDomainData_onlyTimeVariables = table2array(subsetTimeDomainData);
-    timeDomainData_onlyTimeVariables(isnan(timeDomainData_onlyTimeVariables)) = 0;
-    timeDomainData_onlyTimeVariables = sparse(timeDomainData_onlyTimeVariables);
-    timeDomain_timeVariableNames = {'DerivedTime','timestamp','systemTick','PacketGenTime'};
-    
-    % Remove un-needed variables from TimeDomainData
-    timeDomainData = removevars(timeDomainData, {'timestamp','systemTick','PacketGenTime',...
-        'PacketRxUnixTime','dataTypeSequence','packetsizes'});
-    
-    %%
-    % Load txt file with code version
-    
-    currentFunctionPath = mfilename('fullpath');
-    [filepath, name, ext] = fileparts(currentFunctionPath);
-    toLoad = [filepath filesep 'VersionInfo.txt'];
-    
-    versionInfo = importdata(toLoad);
-       
-    %%
-    % Save output file if indicated
-    if processFlag == 1
-        disp('Saving output')
-        
-        save(outputFileName,'unifiedDerivedTimes',...
-            'timeDomainData','timeDomainData_onlyTimeVariables','timeDomain_timeVariableNames',...
-            'AccelData','AccelData_onlyTimeVariables','Accel_timeVariableNames',...
-            'PowerData','PowerData_onlyTimeVariables','Power_timeVariableNames',...
-            'FFTData','FFTData_onlyTimeVariables','FFT_timeVariableNames',...
-            'AdaptiveData','AdaptiveData_onlyTimeVariables','Adaptive_timeVariableNames',...
-            'timeDomainSettings','powerSettings','fftSettings','eventLogTable','metaData',...
-            'stimSettingsOut','stimMetaData','stimLogSettings','DetectorSettings','AdaptiveStimSettings',...
-            'AdaptiveEmbeddedRuns_StimSettings','versionInfo','-v7.3');
+        warning('Time domain file is empty')
+        unifiedDerivedTimes=[];
+        timeDomainData_onlyTimeVariables=[];
+        timeDomain_timeVariableNames=[];
+        AccelData_onlyTimeVariables=[];
+        Accel_timeVariableNames=[];
+        PowerData_onlyTimeVariables=[];
+        Power_timeVariableNames=[];
+        FFTData_onlyTimeVariables=[];
+        FFT_timeVariableNames=[];
+        AdaptiveData_onlyTimeVariables=[];
+        Adaptive_timeVariableNames=[];
+        versionInfo=[];
     end
 end
 

--- a/code/createAdaptiveSettingsfromDeviceSettings.m
+++ b/code/createAdaptiveSettingsfromDeviceSettings.m
@@ -7,7 +7,7 @@ function [DetectorSettings,AdaptiveStimSettings,AdaptiveEmbeddedRuns_StimSetting
 % Output:
 %%
 % Load in DeviceSettings.json file
-DeviceSettings = jsondecode(fixMalformedJson(fileread([folderPath filesep 'DeviceSettings.json']),'DeviceSettings'));
+DeviceSettings = deserializeJSON([folderPath filesep 'DeviceSettings.json']);
 
 %%
 % Fix format - Sometimes device settings is a struct or cell array

--- a/code/createDeviceSettingsTable.m
+++ b/code/createDeviceSettingsTable.m
@@ -15,7 +15,7 @@ function [TD_SettingsOut, Power_SettingsOut, FFT_SettingsOut, metaData] = create
 % Requires convertTDcodes.m
 %%
 % Load in DeviceSettings.json file
-DeviceSettings = jsondecode(fixMalformedJson(fileread([folderPath filesep 'DeviceSettings.json']),'DeviceSettings'));
+DeviceSettings = deserializeJSON([folderPath filesep 'DeviceSettings.json']);
 %%
 % Fix format - Sometimes device settings is a struct or cell array
 if isstruct(DeviceSettings)

--- a/code/createEventLogTable.m
+++ b/code/createEventLogTable.m
@@ -5,11 +5,7 @@ function [eventLogTable] = createEventLogTable(folderPath)
 % Input: Folder path to Device* folder containing json files
 %%
 % Load in EventLog.json
-try
-    eventLog = jsondecode(fixMalformedJson(fileread([folderPath filesep 'EventLog.json']),'EventLog'));
-catch
-    eventLog = deserializeJSON([folderPath filesep 'EventLog.json']);
-end
+eventLog = deserializeJSON([folderPath filesep 'EventLog.json']);
 
 eventLogTable = table();
 if ~isempty(eventLog)

--- a/code/createStimSettingsFromDeviceSettings.m
+++ b/code/createStimSettingsFromDeviceSettings.m
@@ -11,7 +11,7 @@ function [stimSettingsOut, stimMetaData] = createStimSettingsFromDeviceSettings(
 stimSettingsOut = table();
 
 %%
-DeviceSettings = jsondecode(fixMalformedJson(fileread([folderPath filesep 'DeviceSettings.json']),'DeviceSettings'));
+DeviceSettings = deserializeJSON([folderPath filesep 'DeviceSettings.json']);
 %%
 % Fix format - Sometimes device settings is a struct or cell array
 if isstruct(DeviceSettings)

--- a/code/createStimSettingsTable.m
+++ b/code/createStimSettingsTable.m
@@ -7,7 +7,7 @@ function [stimLogSettings] = createStimSettingsTable(folderPath,stimMetaData)
 % Output: stimLogSettings
 %%
 % Load in StimLog.json file
-stimLog = jsondecode(fixMalformedJson(fileread([folderPath filesep 'StimLog.json']),'StimLog'));
+stimLog = deserializeJSON([folderPath filesep 'StimLog.json']);
 if isstruct(stimLog)
     stimLog = {stimLog};
 end

--- a/code/createTimeDomainTable.m
+++ b/code/createTimeDomainTable.m
@@ -8,8 +8,9 @@ srates = getSampleRate([TDdat.TimeDomainData.SampleRate]');
 
 % Determine number of channels per packet
 tdtmp = TDdat.TimeDomainData;
-for p = 1:size(tdtmp,2)
-    nChans(p,1) = size(tdtmp(p).ChannelSamples,2);
+nChans=zeros(length(tdtmp),1);
+for p = 1:length(tdtmp)
+    nChans(p,1) = length(tdtmp(p).ChannelSamples);
 end
 
 % Determine number of samples per packet

--- a/code/deserializeJSON.m
+++ b/code/deserializeJSON.m
@@ -18,33 +18,16 @@ try
 catch
     warning('Not able to open file - attempting fix');
     fprintf('Defective file %s\n',filename);
+    [~,jsonFileName,~]=fileparts(filename);
     
-    % Try to fix the file; separate fixes for Adaptive vs all other JSON
-    % file types
-    dat = fileread(filename);
-    [~,jsonFileName,~] = fileparts(filename);
-    
-    if strcmp(jsonFileName,'AdaptiveLog')
-        adaptiveFile = filename;
-        try
-            data = jsondecode(fixMalformedJson(fileread(adaptiveFile),'AdaptiveLog'));
+    try
+        data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName));
+    catch
+        try 
+            data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName,false));
         catch
             data = [];
-        end
-    else
-        if strcmp(dat(end),'}')  % it's missing the end closing brackets
-            fileID = fopen(filename,'a');
-            fprintf(fileID,'%s',']}]');
-            fclose(fileID);
-            try
-                data = json.load(filename);
-                fprintf('File loaded in %.2f seconds\n',toc(start));
-            catch
-                fprintf('File failed to load problem with json\n');
-                data = [];
-            end
-        else
-            data = [];
+            warning('Failed to fix')
         end
     end
 end

--- a/code/deserializeJSON.m
+++ b/code/deserializeJSON.m
@@ -16,20 +16,18 @@ try
     data = json.load(filename);
     fprintf('File loaded in %.2f seconds\n',toc(start));
 catch
-    warning('Not able to open file - attempting fix');
-    fprintf('Defective file %s\n',filename);
     [~,jsonFileName,~]=fileparts(filename);
     
     try
         % First attempt to fix by simply adding missing curly and square braces
         data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName));
     catch
-        try 
+        try
             % If this fix fails, attempt to remove last record in JSON array
             data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName,false));
         catch
             data = [];
-            warning('Failed to fix')
+            warning('Failed to load %s\n', filename);
         end
     end
 end

--- a/code/deserializeJSON.m
+++ b/code/deserializeJSON.m
@@ -21,9 +21,11 @@ catch
     [~,jsonFileName,~]=fileparts(filename);
     
     try
+        % First attempt to fix by simply adding missing curly and square braces
         data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName));
     catch
         try 
+            % If this fix fails, attempt to remove last record in JSON array
             data = jsondecode(fixMalformedJson(fileread(filename),jsonFileName,false));
         catch
             data = [];

--- a/code/fixMalformedJson.m
+++ b/code/fixMalformedJson.m
@@ -1,4 +1,8 @@
-function [ jsonStringOut ] = fixMalformedJson( jsonString, type )
+function [ jsonStringOut ] = fixMalformedJson( jsonString, type, simple)
+
+if nargin < 3
+    simple=true;
+end
 
 jsonString = strrep(jsonString,'INF','Inf'); % change inproper infinite labels
 
@@ -8,14 +12,32 @@ numCloseCurl = size(find(jsonString=='}'),2);
 numCloseSqua = size(find(jsonString==']'),2);
 
 %Perform JSON formating fix depending on the file type.
-if numOpenSqua~=numCloseSqua && (contains(type,'Log') || contains(type,'Settings'))
-    jsonStringOut = strcat(jsonString,']'); % add missing bracket to the end
-    disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing')
-elseif numOpenSqua~=numCloseSqua || numOpenCurl~=numCloseCurl
-    %Put Fix here for adding in missing brackets at the end of the file.  Assume I want all curls, then all squares, and always end with }]
-    jsonStringfix = strcat(repmat('}',1,(numOpenCurl-numCloseCurl-1)),repmat(']',1,(numOpenSqua-numCloseSqua-1)),'}]');
-    jsonStringOut = strcat(jsonString,jsonStringfix);
-    disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing') 
+if simple
+    if numOpenSqua~=numCloseSqua && numOpenCurl==numCloseCurl
+        jsonStringOut = strcat(jsonString,']'); % add missing bracket to the end
+        disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing')
+    elseif numOpenSqua~=numCloseSqua || numOpenCurl~=numCloseCurl
+        %Put Fix here for adding in missing brackets at the end of the file.  Assume I want all curls, then all squares, and always end with }]
+        jsonStringfix = strcat(repmat('}',1,(numOpenCurl-numCloseCurl-1)),repmat(']',1,(numOpenSqua-numCloseSqua-1)),'}]');
+        jsonStringOut = strcat(jsonString,jsonStringfix);
+        disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing') 
+    else
+        jsonStringOut = jsonString;
+    end
 else
-    jsonStringOut = jsonString;
+    disp('Simple fix failed, attempting to remove the last record')
+    if contains(type,'Accel') || contains(type,'Power') || contains(type,'FFT') || contains(type,'TD')
+        objs=split(jsonString,'{"Header"');
+        info=objs{1};
+        objs=objs(2:end-1);
+        objs=strcat('{"Header"',objs);
+        jsonStringOut=strjoin(objs);
+        jsonStringOut=[info,jsonStringOut(1:end-1),']}]'];
+    elseif contains(type,'Settings')
+        objs=split(jsonString,'{"RecordInfo"');
+        objs=objs(2:end-1);
+        objs=strcat('{"RecordInfo"',objs);
+        jsonStringOut=strjoin(objs);
+        jsonStringOut=['[',jsonStringOut(1:end-1),']'];
+    end
 end

--- a/code/fixMalformedJson.m
+++ b/code/fixMalformedJson.m
@@ -1,5 +1,6 @@
 function [ jsonStringOut ] = fixMalformedJson( jsonString, type, simple)
 
+% Flag to use simple approach to fixing malformed files
 if nargin < 3
     simple=true;
 end
@@ -26,6 +27,10 @@ if simple
     end
 else
     disp('Simple fix failed, attempting to remove the last record')
+    % Accel, Power, FFT, and TD files primarily consist of a JSON array
+    % where each entry begins with a Header field. DeviceSettings, StimLog files have
+    % a similar structure but begin with RecordInfo. Write errors can be
+    % fixed by removing the last entry in the array.
     if contains(type,'Accel') || contains(type,'Power') || contains(type,'FFT') || contains(type,'TD')
         objs=split(jsonString,'{"Header"');
         info=objs{1};
@@ -33,7 +38,7 @@ else
         objs=strcat('{"Header"',objs);
         jsonStringOut=strjoin(objs);
         jsonStringOut=[info,jsonStringOut(1:end-1),']}]'];
-    elseif contains(type,'Settings')
+    elseif contains(type,'DeviceSettings') || contains(type,'StimLog')
         objs=split(jsonString,'{"RecordInfo"');
         objs=objs(2:end-1);
         objs=strcat('{"RecordInfo"',objs);

--- a/code/fixMalformedJson.m
+++ b/code/fixMalformedJson.m
@@ -28,17 +28,18 @@ if simple
 else
     disp('Simple fix failed, attempting to remove the last record')
     % Accel, Power, FFT, and TD files primarily consist of a JSON array
-    % where each entry begins with a Header field. DeviceSettings, StimLog files have
-    % a similar structure but begin with RecordInfo. Write errors can be
-    % fixed by removing the last entry in the array.
+    % where each entry begins with a Header field. DeviceSettings, AdaptiveLog, 
+    % EventLog, and StimLog files have a similar structure but begin with RecordInfo. 
+    % Write errors can be fixed by removing the last entry in the array.
     if contains(type,'Accel') || contains(type,'Power') || contains(type,'FFT') || contains(type,'TD')
+        % Assuming only one RecordInfo to start the file
         objs=split(jsonString,'{"Header"');
         info=objs{1};
         objs=objs(2:end-1);
         objs=strcat('{"Header"',objs);
         jsonStringOut=strjoin(objs);
         jsonStringOut=[info,jsonStringOut(1:end-1),']}]'];
-    elseif contains(type,'DeviceSettings') || contains(type,'StimLog')
+    elseif contains(type,'DeviceSettings') || contains(type,'StimLog') || contains(type,'Adaptive') || contains(type,'EventLog')
         objs=split(jsonString,'{"RecordInfo"');
         objs=objs(2:end-1);
         objs=strcat('{"RecordInfo"',objs);

--- a/code/getActualAmplifierGains.m
+++ b/code/getActualAmplifierGains.m
@@ -2,7 +2,7 @@ function AmpGains = getActualAmplifierGains(folderPath)
 % gets the gain of the amplifier (Amp channel: 1,2,3,4)
 
 % Load in DeviceSettings.json file
-DeviceSettings = jsondecode(fixMalformedJson(fileread([folderPath filesep 'DeviceSettings.json']),'DeviceSettings'));
+DeviceSettings = deserializeJSON([folderPath filesep 'DeviceSettings.json']);
 
 %%
 % Fix format - Sometimes device settings is a struct or cell array


### PR DESCRIPTION
Added code to remove final entries in JSON arrays if simple malformed file fixes are unsuccessful. 
Centralized all `create` functions to load JSON via `deserializeJson`.
Adjusted code in `createTimeDomainTable` to be agnostic of the orientation of 1D vectors.