### PR TITLE
fixes bin indexing

### DIFF
--- a/code/getFFTparameters.m
+++ b/code/getFFTparameters.m
@@ -9,9 +9,19 @@ fftSize = currentFFTconfig.size;
 numBins = fftSize/2;
 binWidth = (currentTDsampleRate/2)/numBins;
 
-lower = (0:numBins-1)*binWidth;
-fftBins = lower + binWidth/2;          % Bin center
-upper = lower + binWidth;
+%% OLD CODE
+%lower = (0:numBins-1)*binWidth;
+%fftBins = lower + binWidth/2;          % Bin center
+%upper = lower + binWidth;
+
+%% NEW CODE: 
+% This fix aligns FFT bin labeling with the way it is processed 
+% by Medtornic hardware. This code takes into consideration that
+% the first bin is centered at zero, rather than at binwidth/2. 
+
+upper = (0:numBins-1)*binWidth + binWidth/2; 
+lower = upper - binWidth;
+fftBins = upper - binWidth/2;     
 
 fftParameters.numBins = numBins;
 fftParameters.binWidth = binWidth;


### PR DESCRIPTION
This fix aligns FFT bin labeling with the way it is processed 
by Medtornic hardware. This code takes into consideration that the first bin is centered at zero, rather than at binwidth/2. 